### PR TITLE
feat: Replace AutoClicker with LeftClicker and RighClicker

### DIFF
--- a/src/main/java/keystrokesmod/module/ModuleManager.java
+++ b/src/main/java/keystrokesmod/module/ModuleManager.java
@@ -214,7 +214,6 @@ public class ModuleManager {
         this.addModule(staffDetector = new StaffDetector());
         this.addModule(new AutoWeapon());
         this.addModule(autoRespawn = new AutoRespawn());
-      	this.addModule(autoRespawn = new AutoRespawn());
         this.addModule(leftClicker = new LeftClicker());
         this.addModule(new RightClicker());
         antiBot.enable();

--- a/src/main/java/keystrokesmod/module/ModuleManager.java
+++ b/src/main/java/keystrokesmod/module/ModuleManager.java
@@ -1,6 +1,5 @@
 package keystrokesmod.module;
 
-import keystrokesmod.module.impl.client.CommandLine;
 import keystrokesmod.module.impl.client.*;
 import keystrokesmod.module.impl.combat.*;
 import keystrokesmod.module.impl.fun.*;
@@ -33,7 +32,7 @@ public class ModuleManager {
     public static Module antiBot;
     public static Module noSlow;
     public static KillAura killAura;
-    public static AutoClicker autoClicker;
+    //public static AutoClicker autoClicker;
     public static HitBox hitBox;
     public static Reach reach;
     public static BedESP bedESP;
@@ -92,9 +91,10 @@ public class ModuleManager {
     public static StaffDetector staffDetector;
     public static AutoRespawn autoRespawn;
     public static Clutch clutch;
+    public static LeftClicker leftClicker;
     
     public void register() {
-        this.addModule(autoClicker = new AutoClicker());
+        //this.addModule(autoClicker = new AutoClicker());
         this.addModule(longJump = new LongJump());
         this.addModule(new AimAssist());
         this.addModule(blink = new Blink());
@@ -214,6 +214,9 @@ public class ModuleManager {
         this.addModule(staffDetector = new StaffDetector());
         this.addModule(new AutoWeapon());
         this.addModule(autoRespawn = new AutoRespawn());
+      	this.addModule(autoRespawn = new AutoRespawn());
+        this.addModule(leftClicker = new LeftClicker());
+        this.addModule(new RightClicker());
         antiBot.enable();
         commandChat.enable();
         modules.sort(Comparator.comparing(Module::getPrettyName));

--- a/src/main/java/keystrokesmod/module/impl/combat/HitSelect.java
+++ b/src/main/java/keystrokesmod/module/impl/combat/HitSelect.java
@@ -39,7 +39,7 @@ public class HitSelect extends Module {
         return MODES[(int) mode.getInput()];
     }
 
-    @SubscribeEvent(priority = EventPriority.LOWEST)
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onAttack(@NotNull AttackEntityEvent event) {
         if (mode.getInput() == 1 && !currentShouldAttack && (!smart.isToggled()
                 || !(event.target instanceof EntityLivingBase)

--- a/src/main/java/keystrokesmod/module/impl/combat/LeftClicker.java
+++ b/src/main/java/keystrokesmod/module/impl/combat/LeftClicker.java
@@ -1,0 +1,209 @@
+package keystrokesmod.module.impl.combat;
+
+import keystrokesmod.module.Module;
+import keystrokesmod.module.ModuleManager;
+import keystrokesmod.module.impl.other.RecordClick;
+import keystrokesmod.module.setting.impl.ButtonSetting;
+import keystrokesmod.module.setting.impl.DescriptionSetting;
+import keystrokesmod.module.setting.impl.ModeSetting;
+import keystrokesmod.module.setting.impl.SliderSetting;
+import keystrokesmod.module.setting.utils.ModeOnly;
+import keystrokesmod.utility.Reflection;
+import keystrokesmod.utility.Utils;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockLiquid;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.inventory.GuiInventory;
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.BlockPos;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
+import net.minecraftforge.fml.common.gameevent.TickEvent.RenderTickEvent;
+import org.jetbrains.annotations.NotNull;
+import org.lwjgl.input.Keyboard;
+import org.lwjgl.input.Mouse;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Random;
+
+public class LeftClicker extends Module {
+    public ModeSetting mode;
+    public SliderSetting minCPS;
+    public SliderSetting maxCPS;
+    public SliderSetting jitter;
+    public ButtonSetting breakBlocks;
+    public ButtonSetting inventoryFill;
+    public ButtonSetting weaponOnly;
+    private final ModeSetting clickSound;
+    private Random rand = null;
+    private long nextReleaseClickTime;
+    private long nextClickTime;
+    private boolean hol;
+    private Method gs;
+
+    public LeftClicker() {
+        super("LeftClicker", Module.category.combat, 0);
+        this.registerSetting(new DescriptionSetting("Best with delay remover."));
+        this.registerSetting(mode = new ModeSetting("Mode", new String[]{"CPS", "Record"}, 0));
+        final ModeOnly mode0 = new ModeOnly(mode, 0);
+        this.registerSetting(minCPS = new SliderSetting("Min CPS", 9.0, 1.0, 20.0, 0.5, mode0));
+        this.registerSetting(maxCPS = new SliderSetting("Max CPS", 12.0, 1.0, 20.0, 0.5, mode0));
+        this.registerSetting(jitter = new SliderSetting("Jitter", 0.0, 0.0, 3.0, 0.1));
+        this.registerSetting(breakBlocks = new ButtonSetting("Break blocks", false));
+        this.registerSetting(inventoryFill = new ButtonSetting("Inventory fill", false));
+        this.registerSetting(weaponOnly = new ButtonSetting("Weapon only", false));
+        this.registerSetting(clickSound = new ModeSetting("Click sound", new String[]{"None", "Standard", "Double", "Alan"}, 0));
+
+        
+        try {
+            this.gs = GuiScreen.class.getDeclaredMethod("func_73864_a", Integer.TYPE, Integer.TYPE, Integer.TYPE);
+        } catch (Exception var4) {
+            try {
+                this.gs = GuiScreen.class.getDeclaredMethod("mouseClicked", Integer.TYPE, Integer.TYPE, Integer.TYPE);
+            } catch (Exception ignored) {
+            }
+        }
+
+        if (this.gs != null) {
+            this.gs.setAccessible(true);
+        }
+    }
+
+    public void onEnable() {
+        this.rand = new Random();
+    }
+
+    public void onDisable() {
+        this.nextReleaseClickTime = 0L;
+        this.nextClickTime = 0L;
+        this.hol = false;
+    }
+
+    public void guiUpdate() {
+        Utils.correctValue(minCPS, maxCPS);
+    }
+
+    @SubscribeEvent
+    public void onRenderTick(@NotNull RenderTickEvent ev) {
+        if (ev.phase != Phase.END && Utils.nullCheck() && !mc.thePlayer.isEating() && mc.objectMouseOver != null && HitSelect.canAttack(mc.objectMouseOver.entityHit)) {
+            if (mc.currentScreen == null && mc.inGameHasFocus) {
+                if (Mouse.isButtonDown(0) && !(weaponOnly.isToggled() && !Utils.holdingWeapon())) {
+                                        this.dc(mc.gameSettings.keyBindAttack.getKeyCode(), 0);
+                } else {
+                    this.nextReleaseClickTime = 0L;
+                    this.nextClickTime = 0L;
+                }
+            } else if (inventoryFill.isToggled() && mc.currentScreen instanceof GuiInventory) {
+                if (!Mouse.isButtonDown(0) || !Keyboard.isKeyDown(54) && !Keyboard.isKeyDown(42)) {
+                    this.nextReleaseClickTime = 0L;
+                    this.nextClickTime = 0L;
+                } else if (this.nextReleaseClickTime != 0L && this.nextClickTime != 0L) {
+                    if (System.currentTimeMillis() > this.nextClickTime) {
+                        this.gd();
+                        this.inventoryClick(mc.currentScreen);
+                    }
+                } else {
+                    this.gd();
+                }
+            }
+        }
+    }
+
+    public void dc(int key, int mouse) {
+        if (breakBlocks.isToggled() && mouse == 0 && mc.objectMouseOver != null) {
+            BlockPos p = mc.objectMouseOver.getBlockPos();
+            if (p != null) {
+                Block bl = mc.theWorld.getBlockState(p).getBlock();
+                if (bl != Blocks.air && !(bl instanceof BlockLiquid)) {
+                    if (!this.hol) {
+                        KeyBinding.setKeyBindState(key, true);
+                        KeyBinding.onTick(key);
+                        this.hol = true;
+                        if (clickSound.getInput() != 0) {
+                            mc.thePlayer.playSound(
+                                    "keystrokesmod:click." + clickSound.getOptions()[(int) clickSound.getInput()].toLowerCase()
+                                    , 1, 1
+                            );
+                        }
+                    }
+                    return;
+                }
+
+                if (this.hol) {
+                    KeyBinding.setKeyBindState(key, false);
+                    this.hol = false;
+                }
+            }
+        }
+
+        if (jitter.getInput() > 0.0D) {
+            double a = jitter.getInput() * 0.45D;
+            EntityPlayerSP var10000;
+            if (this.rand.nextBoolean()) {
+                var10000 = mc.thePlayer;
+                var10000.rotationYaw = (float) ((double) var10000.rotationYaw + (double) this.rand.nextFloat() * a);
+            } else {
+                var10000 = mc.thePlayer;
+                var10000.rotationYaw = (float) ((double) var10000.rotationYaw - (double) this.rand.nextFloat() * a);
+            }
+
+            if (this.rand.nextBoolean()) {
+                var10000 = mc.thePlayer;
+                var10000.rotationPitch = (float) ((double) var10000.rotationPitch + (double) this.rand.nextFloat() * a * 0.45D);
+            } else {
+                var10000 = mc.thePlayer;
+                var10000.rotationPitch = (float) ((double) var10000.rotationPitch - (double) this.rand.nextFloat() * a * 0.45D);
+            }
+        }
+
+        if (this.nextClickTime > 0L && this.nextReleaseClickTime > 0L) {
+            if (System.currentTimeMillis() > this.nextClickTime && KillAura.target == null && !ModuleManager.killAura.swing) {
+                KeyBinding.setKeyBindState(key, true);
+                RecordClick.click();
+                KeyBinding.onTick(key);
+                Reflection.setButton(mouse, true);
+                if (clickSound.getInput() != 0) {
+                    mc.thePlayer.playSound(
+                            "keystrokesmod:click." + clickSound.getOptions()[(int) clickSound.getInput()].toLowerCase()
+                            , 1, 1
+                    );
+                }
+                this.gd();
+            } else if (System.currentTimeMillis() > this.nextReleaseClickTime) {
+                KeyBinding.setKeyBindState(key, false);
+                Reflection.setButton(mouse, false);
+            }
+        } else {
+            this.gd();
+        }
+    }
+
+    public void gd() {
+        switch ((int) mode.getInput()) {
+            case 0:
+                double c = Utils.getRandomValue(minCPS, maxCPS, this.rand) + 0.4D * this.rand.nextDouble();
+                long d = (int) Math.round(1000.0D / c);
+                this.nextClickTime = System.currentTimeMillis() + d;
+                this.nextReleaseClickTime = System.currentTimeMillis() + d / 2L - (long) this.rand.nextInt(10);
+                break;
+            case 1:
+                this.nextClickTime = RecordClick.getNextClickTime();
+                this.nextReleaseClickTime = this.nextClickTime + 1;
+                break;
+        }
+    }
+
+    private void inventoryClick(@NotNull GuiScreen s) {
+        int x = Mouse.getX() * s.width / mc.displayWidth;
+        int y = s.height - Mouse.getY() * s.height / mc.displayHeight - 1;
+
+        try {
+            this.gs.invoke(s, x, y, 0);
+            RecordClick.click();
+        } catch (IllegalAccessException | InvocationTargetException ignored) {
+        }
+    }
+}

--- a/src/main/java/keystrokesmod/module/impl/player/RightClicker.java
+++ b/src/main/java/keystrokesmod/module/impl/player/RightClicker.java
@@ -1,0 +1,152 @@
+package keystrokesmod.module.impl.player;
+
+import keystrokesmod.module.Module;
+import keystrokesmod.module.ModuleManager;
+import keystrokesmod.module.impl.combat.KillAura;
+import keystrokesmod.module.impl.other.RecordClick;
+import keystrokesmod.module.setting.impl.ButtonSetting;
+import keystrokesmod.module.setting.impl.ModeSetting;
+import keystrokesmod.module.setting.impl.SliderSetting;
+import keystrokesmod.module.setting.utils.ModeOnly;
+import keystrokesmod.utility.Reflection;
+import keystrokesmod.utility.Utils;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.item.ItemBlock;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
+import net.minecraftforge.fml.common.gameevent.TickEvent.RenderTickEvent;
+import org.jetbrains.annotations.NotNull;
+import org.lwjgl.input.Mouse;
+
+import java.lang.reflect.Method;
+import java.util.Random;
+
+public class RightClicker extends Module {
+    public ModeSetting mode;
+    public SliderSetting minCPS;
+    public SliderSetting maxCPS;
+    public SliderSetting jitter;
+    public static ButtonSetting rightClick;
+    public ButtonSetting blocksOnly;
+    private final ModeSetting clickSound;
+    private Random rand = null;
+    private long nextReleaseClickTime;
+    private long nextClickTime;
+    private Method gs;
+
+    public RightClicker() {
+        super("RightClicker", Module.category.player, 0);
+        this.registerSetting(mode = new ModeSetting("Mode", new String[]{"CPS", "Record"}, 0));
+        final ModeOnly mode0 = new ModeOnly(mode, 0);
+        this.registerSetting(minCPS = new SliderSetting("Min CPS", 9.0, 1.0, 20.0, 0.5, mode0));
+        this.registerSetting(maxCPS = new SliderSetting("Max CPS", 12.0, 1.0, 20.0, 0.5, mode0));
+        this.registerSetting(jitter = new SliderSetting("Jitter", 0.0, 0.0, 3.0, 0.1));
+        this.registerSetting(blocksOnly = new ButtonSetting("Blocks only", true));
+        this.registerSetting(clickSound = new ModeSetting("Click sound", new String[]{"None", "Standard", "Double", "Alan"}, 0));
+
+        
+        try {
+            this.gs = GuiScreen.class.getDeclaredMethod("func_73864_a", Integer.TYPE, Integer.TYPE, Integer.TYPE);
+        } catch (Exception var4) {
+            try {
+                this.gs = GuiScreen.class.getDeclaredMethod("mouseClicked", Integer.TYPE, Integer.TYPE, Integer.TYPE);
+            } catch (Exception ignored) {
+            }
+        }
+
+        if (this.gs != null) {
+            this.gs.setAccessible(true);
+        }
+    }
+
+    public void onEnable() {
+        this.rand = new Random();
+    }
+
+    public void onDisable() {
+        this.nextReleaseClickTime = 0L;
+        this.nextClickTime = 0L;
+    }
+
+    public void guiUpdate() {
+        Utils.correctValue(minCPS, maxCPS);
+    }
+
+    @SubscribeEvent
+    public void onRenderTick(@NotNull RenderTickEvent ev) {
+        if (ev.phase != Phase.END && Utils.nullCheck() && !mc.thePlayer.isEating() && mc.objectMouseOver != null) {
+            if (mc.currentScreen == null && mc.inGameHasFocus) {
+                if (Mouse.isButtonDown(1)) {
+                    if (blocksOnly.isToggled() && (mc.thePlayer.getCurrentEquippedItem() == null || !(mc.thePlayer.getCurrentEquippedItem().getItem() instanceof ItemBlock))) {
+                        return;
+                    }
+                    this.dc(mc.gameSettings.keyBindUseItem.getKeyCode(), 1);
+                } else {
+                    this.nextReleaseClickTime = 0L;
+                    this.nextClickTime = 0L;
+                }
+            }
+        }
+    }
+
+    public void dc(int key, int mouse) {
+        if (this.nextClickTime > 0L && this.nextReleaseClickTime > 0L) {
+            if (System.currentTimeMillis() > this.nextClickTime && KillAura.target == null && !ModuleManager.killAura.swing) {
+                if (jitter.getInput() > 0.0D) {
+            double a = jitter.getInput() * 0.45D;
+            EntityPlayerSP var10000;
+            if (this.rand.nextBoolean()) {
+                var10000 = mc.thePlayer;
+                var10000.rotationYaw = (float) ((double) var10000.rotationYaw + (double) this.rand.nextFloat() * a);
+            } else {
+                var10000 = mc.thePlayer;
+                var10000.rotationYaw = (float) ((double) var10000.rotationYaw - (double) this.rand.nextFloat() * a);
+            }
+
+            if (this.rand.nextBoolean()) {
+                var10000 = mc.thePlayer;
+                var10000.rotationPitch = (float) ((double) var10000.rotationPitch + (double) this.rand.nextFloat() * a * 0.45D);
+            } else {
+                var10000 = mc.thePlayer;
+                var10000.rotationPitch = (float) ((double) var10000.rotationPitch - (double) this.rand.nextFloat() * a * 0.45D);
+            }
+        }
+                KeyBinding.setKeyBindState(key, true);
+                RecordClick.click();
+                KeyBinding.onTick(key);
+                Reflection.setButton(mouse, true);
+                if (clickSound.getInput() != 0) {
+                    mc.thePlayer.playSound(
+                            "keystrokesmod:click." + clickSound.getOptions()[(int) clickSound.getInput()].toLowerCase()
+                            , 1, 1
+                    );
+                }
+                this.gd();
+
+            } else if (System.currentTimeMillis() > this.nextReleaseClickTime) {
+
+                KeyBinding.setKeyBindState(key, false);
+                Reflection.setButton(mouse, false);
+            }
+        } else {
+            this.gd();
+        }
+    }
+
+    public void gd() {
+        switch ((int) mode.getInput()) {
+            case 0:
+                double c = Utils.getRandomValue(minCPS, maxCPS, this.rand) + 0.4D * this.rand.nextDouble();
+                long d = (int) Math.round(1000.0D / c);
+                this.nextClickTime = System.currentTimeMillis() + d;
+                this.nextReleaseClickTime = System.currentTimeMillis() + d / 2L - (long) this.rand.nextInt(10);
+                break;
+            case 1:
+                this.nextClickTime = RecordClick.getNextClickTime();
+                this.nextReleaseClickTime = this.nextClickTime + 1;
+                break;
+        }
+    }
+}

--- a/src/main/java/keystrokesmod/utility/Utils.java
+++ b/src/main/java/keystrokesmod/utility/Utils.java
@@ -655,8 +655,8 @@ public static List<String> getSidebarLines() {
     }
 
     public static boolean ilc() {
-        if (ModuleManager.autoClicker.isEnabled()) {
-            return AutoClicker.leftClick.isToggled() && Mouse.isButtonDown(0);
+        if (ModuleManager.leftClicker.isEnabled()) {
+            return Mouse.isButtonDown(0);
         } else return CPSCalculator.f() > 1 && System.currentTimeMillis() - CPSCalculator.LL < 300L;
     }
     public static boolean tryingToCombo() {
@@ -838,7 +838,7 @@ public static List<String> getSidebarLines() {
             return false;
         }
         Item getItem = mc.thePlayer.getHeldItem().getItem();
-        return (Settings.weaponSword.isToggled() || getItem instanceof ItemSword) || (Settings.weaponAxe.isToggled() && getItem instanceof ItemAxe) || (Settings.weaponRod.isToggled() && getItem instanceof ItemFishingRod) || (Settings.weaponStick.isToggled() && getItem == Items.stick);
+        return (!Settings.weaponSword.isToggled() || getItem instanceof ItemSword) || (Settings.weaponAxe.isToggled() && getItem instanceof ItemAxe) || (Settings.weaponRod.isToggled() && getItem instanceof ItemFishingRod) || (Settings.weaponStick.isToggled() && getItem == Items.stick);
     }
 
     public static boolean holdingSword() {


### PR DESCRIPTION
This commit replaces the AutoClicker module with a new module called LeftClicker. The new LeftClicker provides similar functionality while also offering additional features like inventory fill and the ability to right-click.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `LeftClicker` for automated left-click actions with settings for CPS, jitter, and more.
  - Added `RightClicker` to simulate right clicks, including CPS, jitter, and sound options.

- **Enhancements**
  - Improved the `HitSelect` module by increasing event priority for better performance.
  - Updated utility functions to align with new `LeftClicker` functionalities.

- **Bug Fixes**
  - Corrected the logic in the `holdingWeapon()` function to improve reliability of weapon checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->